### PR TITLE
Fix LibRead chapters returned in reverse order

### DIFF
--- a/extensions/individual/en/libread/src/io/github/gmathi/novellibrary/extension/en/libread/LibRead.kt
+++ b/extensions/individual/en/libread/src/io/github/gmathi/novellibrary/extension/en/libread/LibRead.kt
@@ -199,7 +199,7 @@ class LibRead : ParsedHttpSource() {
         response: Response,
     ): List<WebPage> {
         val document = response.asJsoup()
-        return document.select(chapterListSelector()).reversed().mapIndexed { index, element ->
+        return document.select(chapterListSelector()).mapIndexed { index, element ->
             val chapter = chapterFromElement(element)
             chapter.orderId = index.toLong()
             chapter


### PR DESCRIPTION
Remove the `.reversed()` call in chapterListParse so chapters are
assigned orderId values in the order they appear on the page (ascending),
matching the expected chapter sequence.

https://claude.ai/code/session_01QWAXKdrXE6bZSW6nhGa8mY